### PR TITLE
Fix jwt x5t

### DIFF
--- a/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
+++ b/components/apimgt/org.wso2.carbon.apimgt.keymgt/src/main/java/org/wso2/carbon/apimgt/keymgt/token/AbstractJWTGenerator.java
@@ -388,10 +388,8 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                 byte[] der = publicCert.getEncoded();
                 digestValue.update(der);
                 byte[] digestInBytes = digestValue.digest();
-                String publicCertThumbprint = hexify(digestInBytes);
-                Base64  base64 = new Base64(true);
-                String base64UrlEncodedThumbPrint = base64.encodeToString(
-                        publicCertThumbprint.getBytes(Charsets.UTF_8)).trim();
+                // Base64  base64 = new Base64(true);
+                String base64UrlEncodedThumbPrint =  java.util.Base64.getEncoder().encodeToString(digestInBytes);
                 StringBuilder jwtHeader = new StringBuilder();
                 //Sample header
                 //{"typ":"JWT", "alg":"SHA256withRSA", "x5t":"a_jhNus21KVuoFx65LmkW2O_l10"}
@@ -399,11 +397,11 @@ public abstract class AbstractJWTGenerator implements TokenGenerator {
                 jwtHeader.append("{\"typ\":\"JWT\",");
                 jwtHeader.append("\"alg\":\"");
                 jwtHeader.append(getJWSCompliantAlgorithmCode(signatureAlgorithm));
-                jwtHeader.append("\",");
+                jwtHeader.append("\"");
 
-                jwtHeader.append("\"x5t\":\"");
-                jwtHeader.append(base64UrlEncodedThumbPrint);
-                jwtHeader.append('\"');
+                // jwtHeader.append("\"x5t\":\"");
+                // jwtHeader.append(base64UrlEncodedThumbPrint);
+                // jwtHeader.append('\"');
 
                 jwtHeader.append('}');
                 return jwtHeader.toString();


### PR DESCRIPTION
## Purpose

Fixing https://github.com/wso2/carbon-apimgt/issues/5884

## Goals

Generate validable JWT backend token
 
## Approach

Encodings of all JWT elements were done using basic Base64 (java.util.Base64) with URL encoding and without wrapping. That made the generated token and signature verfiable by 3rd party tools (usable by backend clients)

## Automation tests

Unfortunate none 

## Security checks

"x5t" jwt header is considered obsolete (using sha-1), we shold use "x5t#256" or make it configurable 

## Test environment

oracle jdk 1.8_181, Amazon Linux2 (CentOS)
 